### PR TITLE
Clarify trust domain and scheme

### DIFF
--- a/draft-ietf-wimse-identifier.md
+++ b/draft-ietf-wimse-identifier.md
@@ -120,7 +120,7 @@ Individual Workload Identifier schemes MAY define additional syntax or processin
 
 ## Scheme Specific Portion
 
-This specification does not define additional structure or semantics for the Workload Identifier beyond the generic URI syntax and the trust domain carried in the authority component. By default, trust domains are opaque strings defined within the scope of a scheme. A particular scheme may define additional semantics for the trust domain. The same trust domain may have different meaning within different schemes.
+This specification does not define additional structure or semantics for the Workload Identifier beyond the generic URI syntax and the trust domain carried in the authority component. Trust domains are opaque strings formatted according to {{Section 3.2.2 of URI}}. A particular scheme may define additional semantics and constraints for the trust domain. The same trust domain may have different meaning within different schemes.
 The structure of path component can be constrained by the scheme. Its contents are deployment-specific and are interpreted according to the scheme, policy of the trust domain, as implemented by the issuer or issuers authorized for that trust domain.
 The issuer defines the granularity at which identities are assigned.
 

--- a/draft-ietf-wimse-identifier.md
+++ b/draft-ietf-wimse-identifier.md
@@ -120,7 +120,7 @@ Individual Workload Identifier schemes MAY define additional syntax or processin
 
 ## Scheme Specific Portion
 
-This specification does not define additional structure or semantics for the Workload Identifier beyond the generic URI syntax and the trust domain carried in the authority component.
+This specification does not define additional structure or semantics for the Workload Identifier beyond the generic URI syntax and the trust domain carried in the authority component. By default, trust domains are opaque strings defined within the scope of a scheme. A particular scheme may define additional semantics for the trust domain. The same trust domain may have different meaning within different schemes.
 The structure of path component can be constrained by the scheme. Its contents are deployment-specific and are interpreted according to the scheme, policy of the trust domain, as implemented by the issuer or issuers authorized for that trust domain.
 The issuer defines the granularity at which identities are assigned.
 
@@ -160,7 +160,7 @@ Other concepts may be represented in the Workload Identifier depending on what i
 
 ## Trust Domain Association
 
-The authority component of the URI defines the trust domain which is responsible for issuing, validating, and managing Workload Identifiers within its scope.  The trust domain SHOULD be a fully qualified domain name belonging to the organization defining the trust domain to help provide uniqueness for the trust domain identifier. The trust domain is treated as an opaque string. While IP addresses are allowed as host names in the URI encoding rules, they MUST NOT be used to represent trust domains except in the case where they are needed for compatibility with legacy naming schemes.
+The authority component of the URI defines the trust domain which is responsible for issuing, validating, and managing Workload Identifiers within its scope.  The trust domain SHOULD be a fully qualified domain name belonging to the organization defining the trust domain to help provide uniqueness for the trust domain identifier. While IP addresses are allowed as host names in the URI encoding rules, they MUST NOT be used to represent trust domains except in the case where they are needed for compatibility with legacy naming schemes.
 
 Workload Identifiers are interpreted as URIs, including the trust domain carried in the authority component. The identifier denotes the workload identity at the granularity assigned by the issuing trust domain, which may correspond to a service, workload class, deployment, individual workload instance, or another deployment-defined concept. Consumers MUST compare and authorize Workload Identifiers using the complete URI, rather than relying only on individual components such as the path.
 


### PR DESCRIPTION
Clarified that a trust domain is scoped by the scheme and that by default it is an opaque string.  A scheme can override this behavior.  

Not that the change in line 163 reverts a change I inadvertently committed to main.  If we reject this PR then we should probably revert that commit.  

This closes #35  and #50 